### PR TITLE
fix: restrict sorting order type to 'asc' or 'desc' in MapCardsProps …

### DIFF
--- a/src/components/maps/map-cards.tsx
+++ b/src/components/maps/map-cards.tsx
@@ -13,7 +13,7 @@ interface MapCardsProps {
     pagination: PaginationState,
     sorting: {
       field: string;
-      order: string;
+      order: 'asc' | 'desc';
     },
   ) => Promise<ServerResponse<PaginationResponse<Maps>>>;
 }


### PR DESCRIPTION
…interface